### PR TITLE
Redundant 'public': 'Mappable' is public extension

### DIFF
--- a/Source/Protocols/Mappable.swift
+++ b/Source/Protocols/Mappable.swift
@@ -22,15 +22,15 @@ public protocol Mappable: ObjectMapper.Mappable {
 public extension Mappable {
 
     ///
-    public init() {
+    init() {
         self.init()
     }
 
     ///
-    public init?(map: Map) {
+    init?(map: Map) {
         self.init()
     }
 
     ///
-    public var data: Data? { return try? JSONSerialization.data(withJSONObject: self.toJSON()) }
+    var data: Data? { return try? JSONSerialization.data(withJSONObject: self.toJSON()) }
 }


### PR DESCRIPTION
This is silencing 3 warnings when building TeslaKit.
Warnings were saying: "'public' modifier is redundant for initializer declared in a public extension"